### PR TITLE
Refactor/remove duplication between class and function extension

### DIFF
--- a/lib/enhanceComponent.js
+++ b/lib/enhanceComponent.js
@@ -106,7 +106,9 @@ const enhanceFromComponent = (Component, screenConfig = null) => {
         return Component;
     }
 
-    return class Enhancer extends Component {
+    const RootComponent = isClass(Component) ? Component : React.Component;
+
+    return class Enhancer extends RootComponent {
         static get displayName() {
             return `withExtras(${Component.displayName || Component.name})`
         }


### PR DESCRIPTION
The extension mechanism for classes vs functional components was different.

One of the core differences is the fact that in order to get a functional component's render tree, it needs to be executed like so `Component()`. With class-based components, we need to call the component's `render` method like so `super.render()` Because of this and a slight difference in markup, we ended up with two functions `enhanceComponentFromClass` and `enhanceComponentFromFunction` which were both returning a class that would render the original component plus the enhancements. 

Those functions have been compressed into a single function and validations that were performed at a superior level, were moved to the level where the extension strategy was decided, this way, trimming down repetitive code.