### PR TITLE
docs(README): Fix import statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ There are no design contstraints when using the library, only a simple nuance wi
 **Import the library into the module where you want to use it:**
 
 ```js
-import { withExtras } from 'render-hijack';
+import withExtras from 'render-hijack';
 ```
 
 **Create your enhanced component:**
 
 ```js
-import { withExtras } from 'render-hijack';
+import withExtras from 'render-hijack';
 
 // ...
 const MenuWithExtras = withExtras({ screenName: 'screen1' })(Menu);


### PR DESCRIPTION
We are not destructuring the `withExtras` export. It is being exported
as a default by the module so no curly braces are required.

Signed-off-by: Adrian Oprea <adrian@oprea.rocks>